### PR TITLE
Update standards based on Nov 2019 PyHC meeting discussion

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -4,13 +4,19 @@
 
 ---
 
-Drafted during the Heliopython Meeting of November 2018.
+Drafted during the Python in Heliophysics Community Meeting of November 2018.
+
+Amended during the Python in Heliophysics Community Meeting of November 2019.
 
 ---
 
-Agreed on 10-Dec-2018 by (in alpahbetical order)
+Agreed on 10-Dec-2018 by (in alphabetical order)
 
 **A. Annex** (JHU), **B. L. Alterman** (Univ. of Michigan), **A. Azari** (Univ. of Michigan), **W. Barnes** (Rice Univ.), **M. Bobra** (Stanford), **B. Cecconi** (Observartoire de Paris), **S. Christe** (NASA GSFC), **J. Coxon** (Univ. of Southampton), **A. DeWolfe** (LASP), **A. Halford** (Aerospace Corporation), **B. Harter** (LASP), **J. Ireland** (NASA GSFC), **J. Jahn** (SwRI), **J. Klenzing** (NASA GSFC), **M. Liu** (SunPy), **J. Mason** (NASA GSFC), **R. McGranaghan** (NASA JPL), **N. Murphy** (CfA), **S. Murray** (Trinity College Dublin), **J. Niehof** (Univ. of New Hampshire), **M.D. Nguyen** (Lomonosov Moscow State Univ.), **R. Panneton** (CU/LASP), **A. Pembroke** (NASA GSFC), **D. Pérez-Suárez** (University College London), **C. Piker** (Univ. of Iowa), **A. Roberts** (NASA GSFC), **D. Ryan** (NASA GSFC), **S. Savage** (NASA GSFC), **J. Smith** (NASA GSFC, Catholic Univ.), **D. Stansby** (Imperial College London), **J. Vandegriff** (JHU/APL), **R. S. Weigel** (George Mason University)
+
+Amended on 05-Nov-2019 by (in alphabetical order)
+
+**N. Murphy** (CfA), 
 
 ---
 
@@ -29,12 +35,13 @@ Definitions:
 5. **License**: Projects must provide a license. Projects should use permissive licenses for open source scientific software (e.g., the BSD 2-clause, BSD 3-clause, or BSD+Patent licenses). Copyleft licenses such as GPL are not recommended and OSI-approved permissive licenses are recommended.
 6. **Version control**: All code must use version control. It is strongly recommended that projects make use of a distributed version control system (e.g., git).
 7. **Coding Style**: Projects must adopt the basic style recommendations of [PEP 8](https://www.python.org/dev/peps/pep-0008/) and static analysis tools should be used to identify deviations from the basic style recommendations (e.g. pylint, flake8, pycodestyle).
-8. **Documentation**: All functions, classes, and modules must have documentation strings (docstrings) provided in a standard [conventions](https://www.python.org/dev/peps/pep-0257/) (e.g. [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html)). Docstrings must describe the code’s purpose, describe all inputs and outputs, and provide examples. High level documentation must also be provided as guides, tutorials, and developer docs. Documentation must be provided in version control with the code and be made available online in a readable form. 
-9. **Testing**: Stable packages must provide unit tests of individual components (e.g. functions, classes) as well as integration tests that test the interaction between components that covers most of the code. Testing coverage should be measured. Automated testing is recommended, in which tests are run before any code is merged. System[link] and acceptance[link] testing are also recommended.
+8. **Documentation**: All functions, classes, and modules in the public-facing application programming interface (API) must have documentation strings (docstrings) provided in a standard [convention](https://www.python.org/dev/peps/pep-0257/) (e.g. [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html)). Docstrings must describe the code’s purpose, describe all inputs and outputs, and provide examples. High level documentation must also be provided as guides, tutorials, and developer docs. Documentation must be provided in version control with the code and be made available online in a readable form. 
+9. **Testing**: Stable packages must provide unit tests of individual components (e.g. functions, classes) as well as integration tests that test the interaction between components that covers most of the code. Testing coverage should be measured. Automated testing is recommended, in which tests are run before any code is merged. System and acceptance testing are also recommended.
 10. **Dependencies**: Projects should import the minimum number of packages necessary. 	Adding new dependencies should be a __considered__ decision.
 11. **Python 3**: All packages must be compatible or work towards being compatible with Python 3. Providing ongoing support for Python 2 is not recommended as the end of life for Python 2 is January 1, 2020 (see [PEP 373](https://www.python.org/dev/peps/pep-0373/)).
-12. **Duplication**: Duplication of code and functionality is discouraged. Forking projects into new projects is strongly discouraged.
-13. **Collaboration**: Contributions to packages must be encouraged. Packages must provide contribution guidelines and clearly explain when a contribution is not accepted.
-14. **Binaries**: Binary files should be added to the package repository only when necessary in order to keep packages as light as possible. Jupyter notebooks can be binary files and should not be committed to the package repository but can be provided in other repositories.
-15. **Code of conduct**:  Each project must adopt a code of conduct that is compatible with the [Contributor Covenant](https://www.contributor-covenant.org) and make it publicly available.
+12. **Deprecation Policy** (in accordance with [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)): Each project should support (1) all minor versions of Python released 42 months prior to the project, and at minimum the two latest minor versions; and (2) all minor versions of NumPy released in the 24 months prior to the project, and at minimum the last three minor versions.  In ``setup.py``, the ``python_requires`` variable should be set to the minimum supported version of Python.  All supported minor versions of Python should be in the test matrix and have binary artifacts built for the release.  Minimum Python and NumPy version support should be adjusted upward only on major and minor releases, and never on a patch release.
 
+13. **Duplication**: Duplication of code and functionality is discouraged. Forking projects into new projects is strongly discouraged.
+14. **Collaboration**: Contributions to packages must be encouraged. Packages must provide contribution guidelines, and clearly and constructively explain when a contribution is not accepted.
+15. **Binaries**: Binary files should be added to the package repository only when necessary in order to keep packages as light as possible. Jupyter notebooks can be binary files and should not be committed to the package repository but can be provided in other repositories.
+16. **Code of conduct**:  Each project must adopt a code of conduct that is compatible with the [Contributor Covenant](https://www.contributor-covenant.org) and make it publicly available.  Each project should have a reporting procedure for reporting violations of the code of conduct and make it publicly available (for a highly detailed example, refer to the [Code of Conduct Response and Enforcement Manual for NumFOCUS](https://numfocus.org/code-of-conduct/response-and-enforcement-events-meetups)).


### PR DESCRIPTION
This pull request is to include changes to the community standards based on the discussion at the PyHC meeting from November 2019.  We probably still need to update the author list to reflect the people who were in attendance in Boulder.  We'll need to review this during a PyHC telecon before we accept this, which will probably be in January 2020.

Here are the notes from the meeting back in November:

 - Change: All functions, classes, and modules **in the public-facing API**...
 - Question: what do people think of [Black](https://pypi.org/project/black/)?
    - It’s opinionated and consistent with the standards
 - Add actual links for “System[link]” and “acceptance[link]”
 - Python 2.7 has about a thousand hours left
 - Change: “clearly **and constructively** explain when a contribution is not accepted”
 - Change in #15: “Projects should have a reporting procedure for violations of the code of conduct (see [link to NumFOCUS’s for ).”
 - Add a bullet point
    - Be explicit on what versions of dependencies a package supports.
    - Strong recommendation that we should support [NumPy Enhancement Proposal 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) which provides recommendations on which prior versions of Python and NumPy to support.
    - “Should” is fine 
 - Do we want to figure out a way to “grade” packages on the PyHC website?
    - Making an assessment can be really useful to packages
    - Probably need someone(s) to go through packages
    - Goes back to governance
    - Self-assessments are a first step; and are important
        - Maybe have a template for that particular type of PR 
    - Maybe if someone wants to add their project to PyHC’s website, then they should provide the results of their self-assessment
    - [Astropy's affiliated packages list](https://www.astropy.org/affiliated/) has a “traffic light system” (red/orange/green)
    - Would be wonderful to have community reviews; really helpful for packages
        - JOSS is a good model for this
    - Should current packages plan on going through this procedure, doing a self-assessment?
    - We’ll need to first figure out what the items to be evaluated on: what the metrics are
    - Does anyone want to volunteer?
        - Eerie silence
    - Bring up at next telecon
    - **By the next meeting in the spring, aim to have all packages on the website reviewed**

